### PR TITLE
Replace miniconda with miniforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 Shared utilities for use within Jenkins jobs
 
 ## Provides
-`conda.install(version="4.3.31", py_maj_version=3, install_dir="miniconda")`
+`conda.install(version="1.2.3", py_maj_version=3, install_dir="miniforge")`
 

--- a/vars/conda.groovy
+++ b/vars/conda.groovy
@@ -1,12 +1,12 @@
 // Shared functionality for managing conda installation.
 
-def install(version="4.3.31", py_maj_version=3, install_dir="miniconda") {
+def install(version="24.3.0-0", py_maj_version=3, install_dir="miniforge") {
 
-    def CONDA_BASE_URL = "https://repo.continuum.io/miniconda"
-    def conda_installers  = ["Linux-py2":"Miniconda2-4.5.4-Linux-x86_64.sh",
-                             "Linux-py3":"Miniconda3-4.5.4-Linux-x86_64.sh",
-                             "MacOSX-py2":"Miniconda2-4.5.4-MacOSX-x86_64.sh",
-                             "MacOSX-py3":"Miniconda3-4.5.4-MacOSX-x86_64.sh"]
+    def CONDA_BASE_URL = "https://ssb.stsci.edu/miniforge"
+    def conda_installers  = ["Linux-py2":"NOT_SUPPORTED",
+                             "Linux-py3":"Miniforge3-${version}-Linux-x86_64.sh",
+                             "MacOSX-py2":"NOT_SUPPORTED",
+                             "MacOSX-py3":"Miniforge3-${version}-MacOSX-x86_64.sh"]
     def OSname = null
     def uname = sh(script: "uname", returnStdout: true).trim()
     if (uname == "Darwin") {
@@ -44,7 +44,7 @@ def install(version="4.3.31", py_maj_version=3, install_dir="miniconda") {
     dl_cmd = dl_cmd + " ${CONDA_BASE_URL}/${conda_installer}"
     sh dl_cmd
 
-    // Install specific version of miniconda
+    // Install specific version of miniforge
     sh "bash ./${conda_installer} -b -p ${conda_install_dir}"
     return true
 }


### PR DESCRIPTION
TLDR; The use of repo.anaconda.com (aka the "defaults" channel) is prohibited.

> OFFERING DESCRIPTION: FREE TIER
...
> 6. Miniconda. In order to access some features and functionalities of Free, You may need to first download and install Miniconda.  
...
> g. Package Updates. Utilizing Miniconda to pull package updates from the Anaconda Public Repository without a commercial license (if required by the conditions set forth in Section 2 of the Terms of Service) is considered a violation of the Terms of Service.
...
> 8. Anaconda Public Repository. 
> a. License Grant. Subject to the terms of this Agreement, Anaconda hereby grants You a non-exclusive, non-transferable license to: (1) Use the Public Repository in accordance to the number of licenses purchased in a non-commercial environment (unless otherwise specified in writing by Anaconda); [...]
...
> 14. Definitions.
> “Anaconda Public Repository”, means the Anaconda packages repository of 8000 open-source data science and machine learning packages at [repo.anaconda.com](http://repo.anaconda.com/).

https://legal.anaconda.com/policies/en/
